### PR TITLE
feat(datepicker): on pupup clear set ngModel to null

### DIFF
--- a/misc/demo/assets/app.js
+++ b/misc/demo/assets/app.js
@@ -1,11 +1,14 @@
 angular.module('dd.ui.demo', ['dd.ui', 'plunker', 'ngTouch', 'ngAnimate', 'ngMockE2E'], function($httpProvider){
   FastClick.attach(document.body);
   delete $httpProvider.defaults.headers.common['X-Requested-With'];
-}).run(['$location', function($location){
+}).run(['$location', '$locale', function($location, $locale){
   //Allows us to navigate to the correct element on initialization
   if ($location.path() !== '' && $location.path() !== '/') {
     smoothScroll(document.getElementById($location.path().substring(1)), 500, function(el) {
-      location.replace(el.id);
+      location.replace('#' + el.id);
     });
   }
+  
+  $locale.DATETIME_FORMATS.FIRSTDAYOFWEEK = 1;
+  
 }]);

--- a/src/dd-datepicker/dd-datepicker.js
+++ b/src/dd-datepicker/dd-datepicker.js
@@ -114,6 +114,9 @@
                             updateDisplayModel(validatedDate);
                         }
                         syncBootstrapDateModel();
+                    } else {
+                        updateMainModel(null);
+                        updateDisplayModel(null);
                     }
                 }
 

--- a/src/dd-datepicker/tests/dd-datepicker.spec.js
+++ b/src/dd-datepicker/tests/dd-datepicker.spec.js
@@ -11,20 +11,22 @@ describe('datetimepicker', function () {
         module('dd.ui.dd-datepicker');
         module('template/dd-datepicker/dd-datepicker.html');
 
-        inject(function ($rootScope, _$compile_, _$sniffer_, _$document_, _$timeout_) {
+        inject(function ($rootScope, _$compile_, _$sniffer_, _$document_, _$timeout_, $locale) {
             $scope = $rootScope.$new();
             $sniffer = _$sniffer_;
             $document = _$document_;
             $compile = _$compile_;
             $timeout = _$timeout_;
 
+            $locale.DATETIME_FORMATS.FIRSTDAYOFWEEK = 1;
+            
             $scope.dateFormat = 'yyyy-MM-dd';
             element = compileElement($scope);
         });
     });
 
     function compileElement($scope) {
-        var element = $compile('<input dd-datepicker date-format="{{dateFormat}}" date-disabled="dateDisabled(date, mode)" ng-model="date" />')($scope);
+        var element = $compile('<input dd-datepicker show-day-name="true" date-format="{{dateFormat}}" date-disabled="dateDisabled(date, mode)" ng-model="date" />')($scope);
         element.appendTo($document[0].body);
         $scope.$digest();
         return element;
@@ -261,6 +263,39 @@ describe('datetimepicker', function () {
             $scope.$digest();
 
             expect($scope.date).toBe(null);
+        });
+    });
+    
+    describe('calendar popup', function() {
+        it('should open calendar popup on btn click', function() {
+            
+            var elementScope = element.isolateScope();
+            
+            element.find('.open-calendar-btn').trigger('click');
+
+            expect(elementScope.calendarOpened).toBe(true);
+        });
+        
+        it('on clear should close calendar', function() {
+            
+            var elementScope = element.isolateScope();
+            
+            element.find('.open-calendar-btn').trigger('click');
+            element.find('.uib-clear').trigger('click');
+            
+            expect(elementScope.calendarOpened).toBe(false);
+        });
+        
+        it('set ngModel from popup selected value', function() {
+            
+            var elementScope = element.isolateScope();
+            
+            element.find('.open-calendar-btn').trigger('click');
+            element.find('.btn.btn-default.btn-sm.active').trigger('click');
+            $scope.$digest();
+
+            expect(elementScope.calendarOpened).toBe(false);
+            expect(elementScope.ngModel).toBeDefined();
         });
     });
 

--- a/src/dd-datetimepicker/dd-datetimepicker.js
+++ b/src/dd-datetimepicker/dd-datetimepicker.js
@@ -47,7 +47,6 @@ angular.module('dd.ui.dd-datetimepicker', ['ui.bootstrap'])
                         
                         updateMainModel();
                         setValidity();
-                        adjustToNextDayIfPossible();
                         adjustDate(newTime, oldTime);
 
                         timepickerBlurEventFired = false;
@@ -117,32 +116,6 @@ angular.module('dd.ui.dd-datetimepicker', ['ui.bootstrap'])
                     scope.$broadcast('ddDatepicker:setDate', { date: dateToSet });
 
                     notifyAboutDatepickerChange();
-                }
-
-                function adjustToNextDayIfPossible() {
-                    if (!scope.date || !scope.time) {
-                        return;
-                    }
-
-                    var currentDay = scope.date.getDate();
-
-                    if (canAddDayIfUserDecreaseTime()) {
-                        scope.date.setDate(currentDay + 1);
-                        updateMainModel();
-                        syncDatepickerModel();
-                        notifyAboutDatepickerChange();
-                    }
-                }
-
-                function canAddDayIfUserDecreaseTime() {
-                    var currentDate = new Date();
-                    currentDate.setSeconds(0);
-                    currentDate.setMilliseconds(0);
-
-                    return scope.allowForwardDateAdjustment &&
-                        sameDay(currentDate, ctrl.$modelValue) &&
-                        timeChanged &&
-                        ctrl.$modelValue.getTime() < currentDate.getTime();
                 }
 
                 function notifyAboutDatepickerChange() {

--- a/src/dd-datetimepicker/docs/readme.md
+++ b/src/dd-datetimepicker/docs/readme.md
@@ -13,10 +13,6 @@ Combined dd-timepicker and dd-datepicker that uses a single Date model.
  	:
  	Set as required field.
      
- * `allow-forward-date-adjustment`
- 	_(Default: false)_ :
- 	If true and user enter time less than current time jump to next day.
-     
  * `show-day-name`
  	_(Default: false)_ :
  	Show day name.

--- a/src/dd-datetimepicker/test/dd-datetimepicker.spec.js
+++ b/src/dd-datetimepicker/test/dd-datetimepicker.spec.js
@@ -141,39 +141,13 @@ describe('dd-datetimepicker', function () {
     });
 
     describe('Adjust date', function () {
-        it('set next day if allowForwardDateAdjustment=true', function () {
-
-            $scope.dateTime = new Date();
-            $scope.allowForwardDateAdjustment = true;
-            $scope.$digest();
-
-            changeInputValue(timepickerElement, $scope.dateTime.getHours() - 1 + ':30');
-            timepickerElement.blur();
-
-            var tomorrow = new Date();
-            tomorrow.setDate(new Date().getDate() + 1);
-            expect(element.isolateScope().ngModel.getDate()).toBe(tomorrow.getDate());
-        });
-
-        it('dont set next day allowForwardDateAdjustment=false', function () {
-
-            $scope.dateTime = new Date('2015-08-30T15:00:00+00:00');
-            $scope.allowForwardDateAdjustment = false;
-            $scope.$digest();
-
-            changeInputValue(timepickerElement, '08:30');
-            timepickerElement.blur();
-
-            expect(element.isolateScope().ngModel.getDate()).toBe(30);
-        });
-
         it('23:59->00:00 = +1 day', function () {
 
             $scope.dateTime = new Date('2015-08-25T15:00:00+00:00');
             $scope.$digest();
 
             changeInputValue(timepickerElement, '23:59');
-            timepickerElement.blur();
+            timepickerElement.trigger('blur');
             triggerKeypress(timepickerElement, 38);
 
             console.log($scope.dateTime);
@@ -187,7 +161,7 @@ describe('dd-datetimepicker', function () {
             $scope.$digest();
 
             changeInputValue(timepickerElement, '00:00');
-            timepickerElement.blur();
+            timepickerElement.trigger('blur');
             triggerKeypress(timepickerElement, 40);
 
             expect($scope.dateTime.getDate()).toBe(24);

--- a/src/dd-timepicker/dd-timepicker.js
+++ b/src/dd-timepicker/dd-timepicker.js
@@ -6,7 +6,7 @@
         .service('timeparserService', timeparserService);
 
     var KEY_ENTER = 13, KEY_UP = 38, KEY_DOWN = 40;
-
+    
     TimepickerDirective.$inject = ['$timeout', 'timeparserService'];
     function TimepickerDirective($timeout, timeparserService) {
 
@@ -24,6 +24,7 @@
                 
                 var dateTime = scope.isDateType && scope.ngModel instanceof Date ? scope.ngModel : new Date();
                 var canUpdateNgModel = false;
+                var lastActionFromArrowKey = false;
 
                 scope.minuteStep = scope.minuteStep || 1;
 
@@ -57,6 +58,11 @@
                         updateViewValue(timeparserService.toView(scope.ngModel));
                         applyOnChange();
                     }
+
+                    if (lastActionFromArrowKey) {
+                        lastActionFromArrowKey = false;
+                        applyOnChange();
+                    }
                 });
 
                 function updateViewValue(value) {
@@ -65,10 +71,9 @@
                 }
 
                 function updateModelOnKeypress(event, delta, customDate) {
-                    canUpdateNgModel = true;
+                    canUpdateNgModel = lastActionFromArrowKey = true;
                     updateViewValue(customDate || timeparserService.changeTime(scope.ngModel, delta));
                     event.preventDefault();
-                    applyOnChange();
                 }
 
                 function isValueChanged() {

--- a/src/dd-timepicker/tests/dd-timepicker.spec.js
+++ b/src/dd-timepicker/tests/dd-timepicker.spec.js
@@ -18,7 +18,7 @@ describe('ddTimepicker', function () {
         });
     });
 
-    describe('Change model value', function () {
+    describe('change model value', function () {
 
         it('apply parsed user input for model', function () {
             element = buildDirective($scope);
@@ -60,47 +60,52 @@ describe('ddTimepicker', function () {
         });
     });
 
-    describe('Keyboard arrow up', function () {
-        it('increase time by one minute', function () {
-            $scope.time = '10:15';
-            element = buildDirective($scope);
+    describe('keyboard', function () {
 
-            triggerKeypress(element, 38);
+        describe('keyboard arrow up', function () {
+            it('increase time by one minute', function () {
+                $scope.time = '10:15';
+                element = buildDirective($scope);
 
-            expect($scope.time).toBe('10:16');
-        });
-    });
+                triggerKeypress(element, 38);
 
-    describe('Keyboard arrow down', function () {
-        it('decrease time by one minute', function () {
-            $scope.time = '10:15';
-            element = buildDirective($scope);
-
-            triggerKeypress(element, 40);
-
-            expect($scope.time).toBe('10:14');
-        });
-    });
-
-    describe('Keyboard enter', function () {
-        it('create time from current datetime if input is empty', function () {
-
-            $scope.time = '';
-            element = buildDirective($scope);
-
-            triggerKeypress(element, 13);
-
-            expect($scope.time).toBeDefined();
+                expect(element.val()).toBe('10:16');
+                expect($scope.time).toBe('10:16');
+            });
         });
 
-        it('dont create time if input not empty', function () {
+        describe('keyboard arrow down', function () {
+            it('decrease time by one minute', function () {
+                $scope.time = '10:15';
+                element = buildDirective($scope);
 
-            $scope.time = '10:10';
-            element = buildDirective($scope);
+                triggerKeypress(element, 40);
 
-            triggerKeypress(element, 13);
+                expect(element.val()).toBe('10:14');
+                expect($scope.time).toBe('10:14');
+            });
+        });
 
-            expect($scope.time).toBe('10:10');
+        describe('keyboard enter', function () {
+            it('create time from current datetime if input is empty', function () {
+
+                $scope.time = '';
+                element = buildDirective($scope);
+
+                triggerKeypress(element, 13);
+
+                expect($scope.time).toBeDefined();
+            });
+
+            it('dont create time if input not empty', function () {
+
+                $scope.time = '10:10';
+                element = buildDirective($scope);
+
+                triggerKeypress(element, 13);
+
+                expect($scope.time).toBe('10:10');
+            });
         });
     });
 
@@ -129,15 +134,39 @@ describe('ddTimepicker', function () {
 
             expect($scope.onChange).toHaveBeenCalledTimes(1);
         });
-        
+
         it('is not called if model changed from code', function () {
 
             $scope.onChange = jasmine.createSpy('onChange');
             $scope.time = '10:15';
             element = buildDirective($scope);
-            
+
             $scope.time = '10:10';
             $scope.$digest();
+
+            expect($scope.onChange).not.toHaveBeenCalled();
+        });
+
+        it('is called on arrow up when blur event fired', function () {
+
+            $scope.onChange = jasmine.createSpy('onChange');
+            $scope.time = '10:15';
+            element = buildDirective($scope);
+
+            triggerKeypress(element, 38);
+            element.trigger('blur');
+            $timeout.flush();
+
+            expect($scope.onChange).toHaveBeenCalled();
+        });
+
+        it('is not called on arrow up when no blur event fired', function () {
+
+            $scope.onChange = jasmine.createSpy('onChange');
+            $scope.time = '10:15';
+            element = buildDirective($scope);
+
+            triggerKeypress(element, 38);
 
             expect($scope.onChange).not.toHaveBeenCalled();
         });

--- a/src/dd-timepicker/tests/dd-timepicker.spec.js
+++ b/src/dd-timepicker/tests/dd-timepicker.spec.js
@@ -18,7 +18,7 @@ describe('ddTimepicker', function () {
         });
     });
 
-    describe('change model value', function () {
+    describe('Change model value', function () {
 
         it('apply parsed user input for model', function () {
             element = buildDirective($scope);
@@ -60,9 +60,9 @@ describe('ddTimepicker', function () {
         });
     });
 
-    describe('keyboard', function () {
+    describe('Keyboard', function () {
 
-        describe('keyboard arrow up', function () {
+        describe('Arrow up', function () {
             it('increase time by one minute', function () {
                 $scope.time = '10:15';
                 element = buildDirective($scope);
@@ -74,7 +74,7 @@ describe('ddTimepicker', function () {
             });
         });
 
-        describe('keyboard arrow down', function () {
+        describe('Arrow down', function () {
             it('decrease time by one minute', function () {
                 $scope.time = '10:15';
                 element = buildDirective($scope);
@@ -86,8 +86,8 @@ describe('ddTimepicker', function () {
             });
         });
 
-        describe('keyboard enter', function () {
-            it('create time from current datetime if input is empty', function () {
+        describe('Enter', function () {
+            it('creates time from current datetime if input is empty', function () {
 
                 $scope.time = '';
                 element = buildDirective($scope);
@@ -97,7 +97,7 @@ describe('ddTimepicker', function () {
                 expect($scope.time).toBeDefined();
             });
 
-            it('dont create time if input not empty', function () {
+            it('doesnt creates time if input not empty', function () {
 
                 $scope.time = '10:10';
                 element = buildDirective($scope);

--- a/template/dd-datepicker/dd-datepicker.html
+++ b/template/dd-datepicker/dd-datepicker.html
@@ -20,7 +20,7 @@
            show-weeks="showWeeks"></div>
         <button ng-disabled="ngDisabled" 
                 type="button" 
-                class="btn btn-default" 
+                class="btn btn-default open-calendar-btn" 
                 ng-click="openCalendar($event)"
                 ng-class="{'calendar-btn-with-day':showDayName}">
                 <i class="glyphicon glyphicon-calendar"></i>


### PR DESCRIPTION
* Clear date model if clear button is clicked in calendar popup
* Fire time changed event only on blur (only for dd-timepicker). dd-datetimepicker will still fire ng-change event on arrow up/down.
* Remove unused dd-datetimepicker logic